### PR TITLE
docs: fix 4-node topology - ring is only option on Spark hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ for (int i = 0; i < handle->num_addrs; i++) {
 ## 🗺️ Roadmap
 
 ### Near-term
-- [ ] **Ring topology support**: Relay routing for non-adjacent nodes (enables 4+ node clusters without full mesh)
+- [ ] **Ring topology support**: Relay routing for non-adjacent nodes (required for 4-node Spark clusters - only 2 NICs per node)
 - [ ] **Dual-channel per port**: Utilize both PCIe 5.0 x4 lanes per ConnectX-7 port for 200Gbps per cable
 - [ ] **Robustness improvements**: Better error handling, recovery, and diagnostics
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -272,19 +272,7 @@ Full mesh becomes impractical beyond 3 nodes (N nodes requires N-1 NICs each, N*
 - **Higher latency for non-neighbors**: 2 hops instead of 1
 - **Relay routing required**: Plugin must forward traffic (planned feature)
 
-### Full Mesh (Alternative)
-
-For maximum performance with 4 nodes, full mesh is still possible:
-```
-    A
-   /|\
-  B-+-C
-   \|/
-    D
-```
-- 6 links, 6 subnets
-- Each node needs 3 NICs
-- Direct communication between all pairs
+> **Note**: Full mesh with 4 nodes would require 3 NICs per node, which isn't possible on DGX Spark (only 2 ConnectX-7 ports per node). Ring topology is the only option for 4-node Spark clusters.
 
 ## Reference: DGX Spark Mesh
 


### PR DESCRIPTION
DGX Spark has exactly 2 ConnectX-7 ports per node (plus 10GbE management). Full mesh with 4 nodes would require 3 NICs per node - not possible. Ring topology is the only viable option for 4-node Spark clusters.