### PR TITLE
feat: add configurable environment variables (TICKET-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,11 @@ for (int i = 0; i < handle->num_addrs; i++) {
 | `NCCL_NET_PLUGIN` | - | Set to `mesh` to use this plugin |
 | `NCCL_DEBUG` | `WARN` | Set to `INFO` for detailed logs |
 | `NCCL_MESH_GID_INDEX` | `3` | RoCE GID index to use |
-| `NCCL_MESH_DEBUG` | `0` | Enable plugin debug output |
+| `NCCL_MESH_DEBUG` | `0` | Debug verbosity: 0=off, 1=info, 2=verbose/trace |
+| `NCCL_MESH_TIMEOUT_MS` | `5000` | Connection timeout in milliseconds |
+| `NCCL_MESH_RETRY_COUNT` | `3` | Number of retry attempts for connections |
 | `NCCL_MESH_FAST_FAIL` | `0` | Fast failure detection (reduced retries). Set to `1` if nodes may OOM/crash |
+| `NCCL_MESH_DISABLE_RDMA` | `0` | Force TCP fallback (not yet implemented) |
 
 ## 🚧 Current Limitations
 


### PR DESCRIPTION
Add new environment variables for runtime configuration:
- NCCL_MESH_DEBUG: Multi-level verbosity (0=off, 1=info, 2=verbose/trace)
- NCCL_MESH_TIMEOUT_MS: Connection timeout in milliseconds (default: 5000)
- NCCL_MESH_RETRY_COUNT: Number of retry attempts (default: 3)
- NCCL_MESH_DISABLE_RDMA: Placeholder for future TCP fallback

Changes:
- Rename debug -> debug_level in mesh_plugin_state for clarity
- Update logging macros to respect debug_level (MESH_INFO at >=1, MESH_DEBUG at >=2)
- Add MESH_TRACE alias for very verbose tracing
- Update mesh_send_handshake to use configurable timeout/retry
- Update mesh_accept timeout to scale with configured timeout (6x)
- Remove hardcoded fprintf statements, convert to MESH_DEBUG where useful
- Update README with new environment variable documentation