### PR TITLE
fix: make TCP isend truly async to prevent deadlock (TICKET-10)

### DIFF
--- a/include/mesh_plugin.h
+++ b/include/mesh_plugin.h
@@ -258,6 +258,8 @@ struct mesh_tcp_request {
     int is_send;                // 1 if send, 0 if recv
     void *comm;                 // Associated comm
     int error;                  // Error code if failed
+    size_t offset;              // TICKET-10: Bytes sent/received so far for async progress
+    int header_sent;            // TICKET-10: 1 if size header already sent (send only)
 };
 
 /*


### PR DESCRIPTION
Root cause: TCP fallback isend() was synchronous/blocking, not async. When both ranks tried to send large tensors simultaneously (650MB all-gather), they would deadlock:
- Rank 0 blocks in isend() waiting for socket buffer to drain
- Rank 1 blocks in isend() waiting for socket buffer to drain
- Neither can call irecv() to drain the other's buffer
- Classic deadlock

Changes:
1. mesh_tcp_request struct: Added offset and header_sent fields to track async send progress

2. mesh_tcp_isend(): Now truly async
   - Sets socket non-blocking
   - Sends as much as possible without blocking
   - If EAGAIN, saves progress in req->offset and returns done=0
   - Caller polls via test() for completion

3. mesh_tcp_test_impl(): Added send continuation logic
   - For incomplete sends, continues from req->offset
   - Handles header send if not yet sent
   - Returns done=0 if still blocked, done=1 when complete

This allows the NCCL polling loop to interleave sends and receives, preventing the deadlock that occurred on SeqNum 16 (_ALLGATHER_BASE).