### PR TITLE
fix: implement FIFO queue for TCP recv requests to allow pipelining (…

### DIFF
--- a/include/mesh_plugin.h
+++ b/include/mesh_plugin.h
@@ -252,8 +252,10 @@ struct mesh_tcp_recv_comm {
     // Buffer for message framing
     uint8_t recv_hdr[8];        // Size header for message framing
 
-    // TICKET-10: Track pending request to prevent overlapping reads
-    struct mesh_tcp_request *pending_req;  // Current in-progress request (NULL if none)
+    // TICKET-10: FIFO queue for pending receive requests
+    // TCP delivers data in-order, so requests must complete in FIFO order
+    struct mesh_tcp_request *recv_queue_head;  // Oldest pending request (dequeue from here)
+    struct mesh_tcp_request *recv_queue_tail;  // Newest pending request (enqueue here)
 };
 
 struct mesh_tcp_request {
@@ -268,6 +270,7 @@ struct mesh_tcp_request {
     int header_sent;            // TICKET-10: 1 if size header already sent (send only)
     int header_recvd;           // TICKET-10: 1 if size header already received (recv only)
     size_t msg_size;            // TICKET-10: Actual message size from header (recv only)
+    struct mesh_tcp_request *next;  // TICKET-10: Next request in FIFO queue (recv only)
 };
 
 /*


### PR DESCRIPTION
…TICKET-10)

The previous fix that rejected overlapping irecv calls was too restrictive. NCCL legitimately needs to post multiple concurrent receive requests for performance pipelining.

Since TCP delivers data in-order, we implement a FIFO queue for receive requests:
- recv_queue_head/recv_queue_tail pointers in mesh_tcp_recv_comm
- next pointer in mesh_tcp_request for linking
- irecv enqueues new requests at tail
- test() only processes the head request (oldest)
- Completed requests are dequeued from head

This allows NCCL to post multiple concurrent irecv requests while ensuring they complete in the correct order matching TCP's byte stream ordering.