### PR TITLE
fix: add FIFO queue for TCP send requests to allow pipelining (TICKET…

### DIFF
--- a/include/mesh_plugin.h
+++ b/include/mesh_plugin.h
@@ -235,8 +235,10 @@ struct mesh_tcp_send_comm {
     // Buffer for message framing
     uint8_t send_hdr[8];        // Size header for message framing
 
-    // TICKET-10: Track pending request to prevent overlapping sends
-    struct mesh_tcp_request *pending_req;  // Current in-progress request (NULL if none)
+    // TICKET-10: FIFO queue for pending send requests
+    // TCP sends data in-order, so requests must complete in FIFO order
+    struct mesh_tcp_request *send_queue_head;  // Oldest pending request (dequeue from here)
+    struct mesh_tcp_request *send_queue_tail;  // Newest pending request (enqueue here)
 };
 
 struct mesh_tcp_recv_comm {


### PR DESCRIPTION
…-10)

Same issue as receives - NCCL also pipelines send operations and needs multiple concurrent isend requests for performance.

Changes:
- Added send_queue_head/send_queue_tail to mesh_tcp_send_comm
- Updated isend to enqueue requests at tail instead of rejecting
- Only process send immediately if at head of queue
- test() only processes send requests that are at queue head
- Dequeue completed send requests from head

This allows NCCL to pipeline both sends and receives while maintaining correct FIFO ordering on each TCP connection.