### PR TITLE
feat: add ncclNet v9 API support for NCCL 2.29 compatibility

### DIFF
--- a/include/nccl/net.h
+++ b/include/nccl/net.h
@@ -37,13 +37,22 @@ typedef void* ncclNetDeviceHandle_t;
 /* Maximum handle size */
 #define NCCL_NET_HANDLE_MAXSIZE 128
 
+/* Maximum number of outstanding requests */
+#define NCCL_NET_MAX_REQUESTS 32
+
+/* Maximum net size */
+#define NCCL_MAX_NET_SIZE_BYTES (1ULL << 31)
+
+/* Device version */
+#define NCCL_NET_DEVICE_INVALID_VERSION 0
+
 /* Net device type */
 typedef enum {
     NCCL_NET_DEVICE_HOST = 0,
     NCCL_NET_DEVICE_UNPACK = 1
 } ncclNetDeviceType;
 
-/* Net properties */
+/* Net properties v8 */
 typedef struct {
     char name[256];
     char pciPath[256];
@@ -57,6 +66,35 @@ typedef struct {
     int netDeviceType;
     int netDeviceVersion;
 } ncclNetProperties_v8_t;
+
+/* Virtual device properties for v9 */
+typedef struct {
+    int ndevs;
+    int* devs;
+} ncclNetVDeviceProps_v9_t;
+
+/* Net properties v9 */
+typedef struct {
+    char* name;
+    char* pciPath;
+    uint64_t guid;
+    int ptrSupport;
+    int regIsGlobal;
+    int forceFlush;
+    int speed;
+    int port;
+    float latency;
+    int maxComms;
+    int maxRecvs;
+    ncclNetDeviceType netDeviceType;
+    int netDeviceVersion;
+    ncclNetVDeviceProps_v9_t vProps;
+    size_t maxP2pBytes;
+    size_t maxCollBytes;
+} ncclNetProperties_v9_t;
+
+/* Net device handle for v9 */
+typedef void* ncclNetDeviceHandle_v9_t;
 
 /* Net plugin v8 interface */
 typedef struct {
@@ -81,7 +119,31 @@ typedef struct {
     ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
 } ncclNet_v8_t;
 
+/* Net plugin v9 interface */
+typedef struct {
+    const char* name;
+    ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+    ncclResult_t (*devices)(int* ndev);
+    ncclResult_t (*getProperties)(int dev, ncclNetProperties_v9_t* props);
+    ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+    ncclResult_t (*connect)(int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v9_t** sendDevComm);
+    ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v9_t** recvDevComm);
+    ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+    ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+    ncclResult_t (*deregMr)(void* comm, void* mhandle);
+    ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void** request);
+    ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** request);
+    ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+    ncclResult_t (*test)(void* request, int* done, int* sizes);
+    ncclResult_t (*closeSend)(void* sendComm);
+    ncclResult_t (*closeRecv)(void* recvComm);
+    ncclResult_t (*closeListen)(void* listenComm);
+    ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+    ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+    ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v9_t* props);
+} ncclNet_v9_t;
+
 /* Plugin version */
-#define NCCL_NET_PLUGIN_SYMBOL ncclNetPlugin_v8
+#define NCCL_NET_PLUGIN_SYMBOL ncclNetPlugin_v9
 
 #endif /* NCCL_NET_H */

--- a/nccl/net.h
+++ b/nccl/net.h
@@ -7,12 +7,13 @@
 
 #include "err.h"
 #include "net_v8.h"
+#include "net_v9.h"
 
 // Maximum number of outstanding requests
 #define NCCL_NET_MAX_REQUESTS 32
 
-// Use v8 as current version
-typedef ncclNet_v8_t ncclNet_t;
-typedef ncclNetProperties_v8_t ncclNetProperties_t;
+// Use v9 as current version
+typedef ncclNet_v9_t ncclNet_t;
+typedef ncclNetProperties_v9_t ncclNetProperties_t;
 
 #endif // NCCL_NET_H

--- a/nccl/net_v9.h
+++ b/nccl/net_v9.h
@@ -1,0 +1,65 @@
+/*
+ * NCCL Net Plugin v9 API
+ */
+
+#ifndef NCCL_NET_V9_H
+#define NCCL_NET_V9_H
+
+#include "err.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/* Virtual device properties for v9 */
+typedef struct {
+    int ndevs;
+    int* devs;
+} ncclNetVDeviceProps_v9_t;
+
+/* Net properties v9 */
+typedef struct {
+    char* name;
+    char* pciPath;
+    uint64_t guid;
+    int ptrSupport;
+    int regIsGlobal;
+    int forceFlush;
+    int speed;
+    int port;
+    float latency;
+    int maxComms;
+    int maxRecvs;
+    int netDeviceType;
+    int netDeviceVersion;
+    ncclNetVDeviceProps_v9_t vProps;
+    size_t maxP2pBytes;
+    size_t maxCollBytes;
+} ncclNetProperties_v9_t;
+
+/* Net device handle for v9 */
+typedef void* ncclNetDeviceHandle_v9_t;
+
+/* Net plugin v9 interface */
+typedef struct {
+    const char* name;
+    ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+    ncclResult_t (*devices)(int* ndev);
+    ncclResult_t (*getProperties)(int dev, ncclNetProperties_v9_t* props);
+    ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+    ncclResult_t (*connect)(int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v9_t** sendDevComm);
+    ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v9_t** recvDevComm);
+    ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+    ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+    ncclResult_t (*deregMr)(void* comm, void* mhandle);
+    ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void** request);
+    ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** request);
+    ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+    ncclResult_t (*test)(void* request, int* done, int* sizes);
+    ncclResult_t (*closeSend)(void* sendComm);
+    ncclResult_t (*closeRecv)(void* recvComm);
+    ncclResult_t (*closeListen)(void* listenComm);
+    ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+    ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+    ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v9_t* props);
+} ncclNet_v9_t;
+
+#endif // NCCL_NET_V9_H


### PR DESCRIPTION
NCCL 2.29 looks for ncclNet_v9 first before falling back to v8.
- Add nccl/net_v9.h with v9 structs and interface
- Add v9 wrapper functions in mesh_plugin.c
- Export both ncclNetPlugin_v9 and ncclNet_v9 symbols
- Keep v8 exports for backward compatibility

The v9 API differs from v8 in:
- size_t instead of int for message sizes
- Additional makeVDevice function
- Properties struct has vProps, maxP2pBytes, maxCollBytes