### PR TITLE
fix: handle sampler without set_epoch after accelerator.prepare()

### DIFF
--- a/examples/train_qwen14b_optimized.py
+++ b/examples/train_qwen14b_optimized.py
@@ -334,7 +334,9 @@ def main():
         print(f"\nStarting training for {max_steps} steps...")
 
     for epoch in range(config["num_epochs"]):
-        dataloader.sampler.set_epoch(epoch)
+        # Accelerate may replace our DistributedSampler, so check for set_epoch
+        if hasattr(dataloader.sampler, 'set_epoch'):
+            dataloader.sampler.set_epoch(epoch)
 
         for step, batch in enumerate(dataloader):
             with accelerator.accumulate(model):


### PR DESCRIPTION
Accelerate replaces DistributedSampler with its own sampler that may not have set_epoch(). Add hasattr check to avoid AttributeError.