### PR TITLE
fix: disable FlashAttention for sm121 GPU compatibility

### DIFF
--- a/examples/train_qwen14b_deepspeed.py
+++ b/examples/train_qwen14b_deepspeed.py
@@ -204,6 +204,7 @@ def main():
     # Load model with memory optimizations
     # Don't use zero.Init() - it doesn't work well with from_pretrained
     # Instead, use low_cpu_mem_usage to load shards incrementally
+    # Use eager attention to avoid FlashAttention sm80-sm100 kernel issues on sm121
     model = AutoModelForCausalLM.from_pretrained(
         args.model_path,
         torch_dtype=torch.bfloat16,
@@ -211,6 +212,7 @@ def main():
         local_files_only=True,
         use_cache=False,  # Required for gradient checkpointing
         low_cpu_mem_usage=True,  # Load shards incrementally
+        attn_implementation="eager",  # Disable FlashAttention for sm121 compatibility
     )
 
     # Enable gradient checkpointing before DeepSpeed init


### PR DESCRIPTION
DGX Spark uses compute capability 12.1 (sm121) which is newer than the sm80-sm100 range that pre-built FlashAttention kernels support. Use eager attention implementation instead.